### PR TITLE
Updated PUT video game method and added web.config

### DIFF
--- a/src/app/vginventory/src/hooks/useUpdateVideoGame.ts
+++ b/src/app/vginventory/src/hooks/useUpdateVideoGame.ts
@@ -8,7 +8,7 @@ const axios = require('axios').default;
 export function useUpdateVideoGame(vg: videoGame) {
     const [videogame, setVideoGame] = useState<videoGame>(vg);
     const [description, setDescription] = useState<string>(vg.description);
-    const url = baseApiUrl.concat('/api/videogames');
+    const url = baseApiUrl.concat(`/api/videogames/${videogame.id}`);
     let history = useHistory();
 
     const updateVideoGame = async () => {

--- a/src/infra/webapi/Controllers/VideoGamesController.cs
+++ b/src/infra/webapi/Controllers/VideoGamesController.cs
@@ -104,10 +104,10 @@ namespace VgInventory.Infra.WebApi.Controllers
 
         #region Update
 
-        [HttpPut]
-        public ActionResult UpdateUser(VideoGame videoGame)
+        [HttpPut("{id}")]
+        public ActionResult UpdateUser(string id, VideoGame videoGame)
         {
-            if (videoGame != null)
+            if (videoGame != null && videoGame.Id == id)
             {
                 var titleToLower = videoGame.Title.ToLower();
                 var entities = DataConnector.ReadAsync((entity) => entity.Title.ToLower().Equals(titleToLower));

--- a/src/infra/webapi/web.config
+++ b/src/infra/webapi/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+    <modules runAllManagedModulesForAllRequests="false">
+        <remove name="WebDAVModule" />
+    </modules>
+  </system.web>
+</configuration>


### PR DESCRIPTION
I do not know if this will work. I found articles that stated that newer versions (2+) of dotnet core were replacing web.config files with appsettings.json.  In short, the appsettings.json provides some security settings but what I've read that will work to allow PUT methods is to edit the applicationHost.config and remove the following line :
`<add name="WebDAVModule" />`

Just in case this does not work, the articles are the following:

- Go to the most recent answers: https://stackoverflow.com/questions/48188895/asp-net-core-with-iis-http-verb-not-allowed
- https://docs.microsoft.com/en-us/iis-administration/configuration/appsettings.json
- https://docs.microsoft.com/en-us/aspnet/web-api/overview/testing-and-debugging/troubleshooting-http-405-errors-after-publishing-web-api-applications